### PR TITLE
Fix typo in Reparing

### DIFF
--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -57,7 +57,7 @@ extension String {
   public static func decodeCString<Encoding : UnicodeCodec>(
     cString: UnsafePointer<Encoding.CodeUnit>,
     as encoding: Encoding.Type,
-    repairingInvalidCodeUnits isReparing: Bool = true)
+    repairingInvalidCodeUnits isRepairing: Bool = true)
       -> (result: String, repairsMade: Bool)? {
 
     if cString._isNull {
@@ -68,7 +68,7 @@ extension String {
       start: cString, count: len)
 
     let (stringBuffer, hadError) = _StringBuffer.fromCodeUnits(
-      buffer, encoding: encoding, repairIllFormedSequences: isReparing)
+      buffer, encoding: encoding, repairIllFormedSequences: isRepairing)
     return stringBuffer.map {
       (result: String(_storage: $0), repairsMade: hadError)
     }


### PR DESCRIPTION
#### What's in this pull request?

Fixes a typo in CString. `Reparing` -> `Repairing`
#### Resolved bug number: ([SR-](https://bugs.swift.org/browse/SR-))

NA

---

<!-- This selection should only be completed by Swift admin -->

Before merging this pull request to apple/swift repository:
- [ ] Test pull request on Swift continuous integration.

<details>
  <summary>

Triggering Swift CI</summary>



The swift-ci is triggered by writing a comment on this PR addressed to the GitHub user @swift-ci. Different tests will run depending on the specific comment that you use. The currently available comments are:

**Smoke Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please smoke test |
| OS X platform | @swift-ci Please smoke test OS X platform |
| Linux platform | @swift-ci Please smoke test Linux platform |

 **Validation Testing**

| Platform | Comment |
| --- | --- |
| All supported platforms | @swift-ci Please test |
| OS X platform | @swift-ci Please test OS X platform |
| Linux platform | @swift-ci Please test Linux platform |

Note: Only members of the Apple organization can trigger swift-ci.
</details>

<!-- Thank you for your contribution to Swift! -->
